### PR TITLE
headers: support custom headers passed to brq

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -78,6 +78,7 @@ class Client extends EventEmitter {
         await this.auth();
       } catch (e) {
         this.emit('error', e);
+        return;
       }
       this.emit('connect');
     });

--- a/lib/client.js
+++ b/lib/client.js
@@ -179,6 +179,7 @@ class Client extends EventEmitter {
       path: this.path + endpoint,
       username: this.username,
       password: this.password,
+      customHeaders: this.headers,
       query: query,
       pool: true,
       json: params
@@ -325,6 +326,7 @@ class ClientOptions {
     this.host = 'localhost';
     this.port = 80;
     this.path = '/';
+    this.headers = null;
     this.username = null;
     this.password = null;
     this.id = null;
@@ -370,6 +372,11 @@ class ClientOptions {
     if (options.key != null) {
       assert(typeof options.key === 'string');
       this.password = options.key;
+    }
+
+    if (options.headers != null) {
+      assert(typeof options.headers === 'object');
+      this.headers = options.headers;
     }
 
     if (options.username != null) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "webpack": "webpack --config webpack.config.js"
   },
   "dependencies": {
-    "brq": "~0.0.2",
+    "brq": "bcoin-org/brq#headers",
     "bsock": "~0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow setting custom headers for client requests. Useful for API clients that require special auth headers.

Depends on brq PR: https://github.com/bcoin-org/brq/pull/2