### PR TITLE
client: help if no rpc command specified

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -275,7 +275,8 @@ class Client extends EventEmitter {
 
   async execute(endpoint, method, params) {
     assert(typeof endpoint === 'string');
-    assert(typeof method === 'string');
+    if (typeof method !== 'string')
+      method = 'help';
 
     if (params == null)
       params = null;


### PR DESCRIPTION
This PR goes along with bcoin PR https://github.com/bcoin-org/bcoin/pull/545 and bclient PR https://github.com/bcoin-org/bclient/pull/11.

Fixes this behavior:
```
$ bcoin-cli rpc
AssertionError: false == true
    at NodeClient.execute (/home/ec2-user/bclient/node_modules/bcurl/lib/client.js:278:5)
    at NodeClient.execute (/home/ec2-user/bclient/lib/node.js:44:18)
    at CLI.rpc (/home/ec2-user/bclient/bin/bcoin-cli:159:34)
    at CLI.open (/home/ec2-user/bclient/bin/bcoin-cli:195:20)
    at /home/ec2-user/bclient/bin/bcoin-cli:221:13
    at Object.<anonymous> (/home/ec2-user/bclient/bin/bcoin-cli:223:3)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
```
Instead, returns the list of RPC commands equivalent to entering `bcoin-cli rpc help`