### PR TITLE
Bug Fix: should not emit connect event if auth fails

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -84,6 +84,7 @@ class Client extends EventEmitter {
         await this.auth();
       } catch (e) {
         this.emit('error', e);
+        return;
       }
       this.emit('connect');
     });


### PR DESCRIPTION
Minor code change that potentially creates breaking changes for downstream clients. though I don't see how this would be useful. I incorrectly included this fix in the `headers` branch, this should have been a separate PR to discuss.

In my usage of bclient I ran into this issue when trying to connect to multiple bcoin nodes. If I handle the `connect` event as a successful connection and node authentication fails, `connect` event is still thrown. This causes unexpected behavior in connection handlers since the connection isn't actually available. Requires downstream clients to maintain a global track of when `error` is thrown, and handle accordingly in `connect` handlers. This creates complicated code paths when re-trying connections regularly.

Example:

```javascript
const {WalletClient} = require('bclient');
const client = new WalletClient({
// wallet auth settings
});

client.on('error', (e) => {
  console.log('Connection error', e);
});
client.on('connect', async (e) => {
  console.log('Successful connection');
  await client.open();
  // ... make wallet requests
});
````

In the current implementation of bcurl, if you pass in a bad API key to `WalletClient` this results in:
```
Connection error { Error: Invalid API key.
Successful connection
(node:82697) UnhandledPromiseRejectionWarning: Error: Call not found: join.
```

My solution here is to simply not emit `connect` when authentication fails. I think this would be the expected behavior.