### PR TITLE
request json.error: test for empty errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -208,7 +208,7 @@ class Client extends EventEmitter {
     if (!json)
       throw new Error('Bad response (no body).');
 
-    if (json.error) {
+    if (json.error && json.error.length) {
       const {error} = json;
       const err = new Error(error.message);
       err.type = String(error.type);


### PR DESCRIPTION
Addresses #9 

Prevents throwing error if the JSON returned has an empty error string, examples:

`{error: [], result: 'Lots of great info you are not gunna get with that error over there'}`
`{error: '', result: 'Lots of great info you are not gunna get with that error over there'}`
`{error: {}, result: 'Lots of great info you are not gunna get with that error over there'}`

`{error: {message: 'bad API KEY', code: 'NOAUTH'}}` --> still throws