### PR TITLE
expose brq `strictSSL`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,6 +29,7 @@ class Client extends EventEmitter {
     const opt = new ClientOptions(options);
 
     this.ssl = opt.ssl;
+    this.strictSSL = opt.strictSSL;
     this.host = opt.host;
     this.port = opt.port;
     this.path = opt.path;
@@ -52,6 +53,7 @@ class Client extends EventEmitter {
   clone() {
     const copy = new this.constructor();
     copy.ssl = this.ssl;
+    copy.strictSSL = this.strictSSL;
     copy.host = this.host;
     copy.port = this.port;
     copy.path = this.path;
@@ -181,6 +183,7 @@ class Client extends EventEmitter {
     const res = await brq({
       method: method,
       ssl: this.ssl,
+      strictSSL: this.strictSSL,
       host: this.host,
       port: this.port,
       path: this.path + endpoint,
@@ -286,6 +289,7 @@ class Client extends EventEmitter {
     const res = await brq({
       method: 'POST',
       ssl: this.ssl,
+      strictSSL: this.strictSSL,
       host: this.host,
       port: this.port,
       path: this.path + endpoint,
@@ -335,6 +339,7 @@ class Client extends EventEmitter {
 class ClientOptions {
   constructor(options) {
     this.ssl = false;
+    this.strictSSL = true;
     this.host = 'localhost';
     this.port = 80;
     this.path = '/';
@@ -360,6 +365,11 @@ class ClientOptions {
       assert(typeof options.ssl === 'boolean');
       this.ssl = options.ssl;
       this.port = 443;
+    }
+
+    if (options.strictSSL != null) {
+      assert(typeof options.strictSSL === 'boolean');
+      this.strictSSL = options.strictSSL;
     }
 
     if (options.host != null) {


### PR DESCRIPTION
This PR accepts a new parameter `strictSSL`, which [already exists in brq](https://github.com/bcoin-org/brq/blob/master/lib/request.js#L38) but was not passed to `brq` when making a request. The default is still set to `true` but there is a use-case for setting this to `false`: When the server is using a self-signed certificate.

This is frequently the case in development environments such as `bPanel` which requires `https` when connected to a hardware wallet. Self-signed certificates are also used by the JSON-RPC in [`btcd`](https://github.com/btcsuite/btcutil/blob/master/certgen.go)

Setting this to false allows me to access the `btcd` JSON-RPC API from bclient without getting this error:
```
(node:78414) UnhandledPromiseRejectionWarning: Error: self signed certificate
    at TLSSocket.onConnectSecure (_tls_wrap.js:1049:34)
    at TLSSocket.emit (events.js:182:13)
    at TLSSocket._finishInit (_tls_wrap.js:631:8)
```