### PR TITLE
client: join path instead of concat.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const EventEmitter = require('events');
 const URL = require('url');
+const Path = require('path').posix;
 const bsock = require('bsock');
 const brq = require('brq');
 
@@ -202,7 +203,7 @@ class Client extends EventEmitter {
       strictSSL: this.strictSSL,
       host: this.host,
       port: this.port,
-      path: this.path + endpoint,
+      path: Path.join(this.path, endpoint),
       username: this.username,
       password: this.password,
       headers: this.headers,
@@ -319,7 +320,7 @@ class Client extends EventEmitter {
       strictSSL: this.strictSSL,
       host: this.host,
       port: this.port,
-      path: this.path + endpoint,
+      path: Path.join(this.path, endpoint),
       username: this.username,
       password: this.password,
       headers: this.headers,


### PR DESCRIPTION
Instead of concatenating two strings, use `path.posix.join` that can normalize path.

Issue: https://github.com/bcoin-org/bcurl/issues/14

somewhat related: https://github.com/bcoin-org/bweb/issues/2
This could also use `path.posix.normalize` instead of `path.normalize`