### PR TITLE
RPCError changes sign of error codes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -515,7 +515,7 @@ class RPCError extends Error {
 
     this.type = 'RPCError';
     this.message = String(msg);
-    this.code = code >>> 0;
+    this.code = code >> 0;
 
     if (Error.captureStackTrace)
       Error.captureStackTrace(this, RPCError);


### PR DESCRIPTION
Codes defined in code, e.g. in rpc server is represented as negative numbers. But does not propagate sign. This will still cast code into number, but will allow negative numbers.