### PR TITLE
tests: fix regression and use path.join

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/node:10.2
+
+version: 2.0
+jobs:
+  install:
+    <<: *defaults
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package-lock.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: npm install
+      - run: npm install bslint nyc codecov
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Tests with coverage
+          command: npm run test-ci
+      - run:
+          name: Submit coverage
+          command: ./node_modules/.bin/codecov
+
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint
+          command: npm run lint-ci
+
+workflows:
+  version: 2
+  test_and_lint:
+    jobs:
+      - install
+      - lint:
+          requires:
+            - install
+      - test:
+          requires:
+            - install

--- a/lib/client.js
+++ b/lib/client.js
@@ -228,7 +228,7 @@ class Client extends EventEmitter {
     if (!json)
       throw new Error('Bad response (no body).');
 
-    if (json.error && json.error.length) {
+    if (json.error && res.statusCode >= 400) {
       const {error} = json;
       const err = new Error(error.message);
       err.type = String(error.type);

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const EventEmitter = require('events');
 const URL = require('url');
+const Path = require('path').posix;
 const bsock = require('bsock');
 const brq = require('brq');
 
@@ -202,7 +203,7 @@ class Client extends EventEmitter {
       strictSSL: this.strictSSL,
       host: this.host,
       port: this.port,
-      path: this.path + endpoint,
+      path: Path.join(this.path, endpoint),
       username: this.username,
       password: this.password,
       headers: this.headers,
@@ -319,7 +320,7 @@ class Client extends EventEmitter {
       strictSSL: this.strictSSL,
       host: this.host,
       port: this.port,
-      path: this.path + endpoint,
+      path: Path.join(this.path, endpoint),
       username: this.username,
       password: this.password,
       headers: this.headers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "bcurl",
+  "version": "0.1.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bmocha": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.2.tgz",
+      "integrity": "sha512-EvcGGQCbRnF3/Uq+gNIrWdNY65eDok17i7AKEY/xTLGFk812GdqEQ/FW8X1X1lyH5IlLshjubDjyC4HRWeCt7g==",
+      "dev": true
+    },
+    "brq": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+    },
+    "bsock": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "brq": "~0.1.8",
     "bsert": "~0.0.10",
-    "bsock": "~0.1.8"
+    "bsock": "~0.1.9"
   },
   "devDependencies": {
     "bmocha": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Christopher Jeffrey <chjjeffrey@gmail.com>",
   "main": "./lib/bcurl.js",
   "scripts": {
-    "lint": "eslint lib/ || exit 0",
+    "lint": "eslint lib/ test/ || exit 0",
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "dependencies": {
@@ -26,7 +26,7 @@
     "bsock": "~0.1.8"
   },
   "devDependencies": {
-    "bmocha": "^2.1.0"
+    "bmocha": "^2.1.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test-ci": "nyc -a -n 'lib/**/*.js' --reporter=lcov --reporter=text npm run test"
   },
   "dependencies": {
-    "brq": "~0.1.7",
+    "brq": "~0.1.8",
     "bsert": "~0.0.10",
     "bsock": "~0.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "main": "./lib/bcurl.js",
   "scripts": {
     "lint": "eslint lib/ test/ || exit 0",
-    "test": "bmocha --reporter spec test/*-test.js"
+    "lint-ci": "eslint lib/ test/",
+    "test": "bmocha --reporter spec test/*-test.js",
+    "test-ci": "nyc -a -n 'lib/**/*.js' --reporter=lcov --reporter=text npm run test"
   },
   "dependencies": {
     "brq": "~0.1.7",

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -1,0 +1,446 @@
+/**
+ * http-test.js - HTTP tests for bcurl
+ */
+
+'use strict';
+
+const http = require('http');
+const assert = require('bsert');
+const Client = require('../lib/client');
+
+if (process.browser)
+  return;
+
+// start the server on this port
+// for each test
+const port = 8118;
+
+// Global variables for the
+// server and client singletons
+// used for each it block.
+let server, client;
+
+// Global boolean that is set
+// to false after each it block.
+let seen = false;
+
+// Start accepts a series of handlers
+// and composes them together. Each
+// handler can have its own assertion
+// or functionality. Sets the global
+// variable seen to true.
+function start(fns) {
+  async function handler(req, res) {
+    for (const fn of fns)
+      await fn(req, res);
+
+    seen = true;
+  }
+
+  return http.createServer(handler)
+    .listen(port);
+}
+
+// Handlers
+// Deeply compare a request property with a target.
+const reqDeepEqual = (a, b) => (req, res) => {
+  assert.deepEqual(req[a], b);
+};
+
+// Deeply compare a request header
+// property with a target.
+const reqHeaderDeepEqual = (a, b) => (req, res) => {
+  const {headers} = req;
+  assert.deepEqual(headers[a], b);
+};
+
+// End the request with the required header.
+const end = () => (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.end();
+};
+
+// Assert on the value of the global
+// variable seen.
+const seenDeepEqual = bool => () => {
+  assert.deepEqual(seen, bool);
+};
+
+const status = code => (req, res) => {
+  res.statusCode = code;
+};
+
+const write = (data, type) => (req, res) => {
+  if (type === 'json') {
+    data = JSON.stringify(data, null, 2) + '\n';
+    res.setHeader('Content-Type', 'application/json');
+  }
+
+  let len = 0;
+  if (typeof data === 'string')
+    len = Buffer.byteLength(data, 'utf8');
+  else
+    len = data.length;
+
+  res.setHeader('Content-Length', len.toString(10));
+  res.write(data, 'utf8');
+};
+
+// Parse the body and assign to
+// the request.
+const parseBody = () => async (req, res) => {
+  await new Promise((resolve, reject) => {
+    let received = '';
+
+    req.on('data', (chunk) => {
+      received += chunk;
+    });
+
+    req.on('end', () => {
+      req.body = received;
+      resolve();
+    });
+
+    req.on('error', reject);
+  });
+};
+
+// End in an unsafe way.
+const unsafeEnd = () => (req, res) => {
+  res.end();
+};
+
+describe('Client HTTP', function() {
+  // Set the global seen variable
+  // to false before each test.
+  beforeEach(async () => {
+    seen = false;
+  });
+
+  // Close the server and set the global
+  // variable seen to null after each it block.
+  afterEach(async () => {
+    server.close();
+    seen = false;
+  });
+
+  it('should use HTTP version 1.1', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('httpVersion', '1.1'),
+      end()
+    ]);
+
+    await client.get('/');
+    assert(seen);
+  });
+
+  it('should send request with headers', async () => {
+    client = new Client({
+      port: port,
+      headers: {foo: 'bar'}
+    });
+
+    server = start([
+      seenDeepEqual(false),
+      reqHeaderDeepEqual('user-agent', 'brq'),
+      reqHeaderDeepEqual('foo', 'bar'),
+      reqHeaderDeepEqual('host', `localhost:${port}`),
+      end()
+    ]);
+
+    await client.get('/');
+    assert(seen);
+  });
+
+  it('should send GET request', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'GET'),
+      reqDeepEqual('url', '/'),
+      end()
+    ]);
+
+    await client.get('/');
+    assert(seen);
+  });
+
+  it('should send GET request with query params', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'GET'),
+      reqDeepEqual('url', '/?query=param'),
+      end()
+    ]);
+
+    await client.get('/', {query: 'param'});
+    assert(seen);
+  });
+
+  it('should send POST request', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'POST'),
+      reqDeepEqual('url', '/'),
+      end()
+    ]);
+
+    await client.post('/');
+    assert(seen);
+  });
+
+  it('should send POST request with body', async () => {
+    client = new Client({port});
+    const body = {a: 'body'};
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'POST'),
+      parseBody(),
+      reqDeepEqual('body', JSON.stringify(body)),
+      end()
+    ]);
+
+    await client.post('/', body);
+    assert(seen);
+  });
+
+  it('should send PUT request', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'PUT'),
+      reqDeepEqual('url', '/'),
+      end()
+    ]);
+
+    await client.put('/');
+    assert(seen);
+  });
+
+  it('should send DELETE request', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'DELETE'),
+      reqDeepEqual('url', '/'),
+      end()
+    ]);
+
+    await client.del('/');
+    assert(seen);
+  });
+
+  it('should send PATCH request', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('method', 'PATCH'),
+      reqDeepEqual('url', '/'),
+      end()
+    ]);
+
+    await client.patch('/');
+    assert(seen);
+  });
+
+  it('should error on the wrong content-type', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      unsafeEnd()
+    ]);
+
+    let err;
+
+    try {
+      await client.get('/');
+    } catch (e) {
+      err = e;
+    }
+
+    assert.deepEqual(err.message, 'Bad response (wrong content-type).');
+    assert(seen);
+  });
+
+  it('should send token in GET request', async () => {
+    const token = '123456';
+    client = new Client({
+      port: port,
+      token: token
+    });
+
+    server = start([
+      seenDeepEqual(false),
+      reqDeepEqual('url', `/?token=${token}`),
+      end()
+    ]);
+
+    await client.get('/');
+    assert(seen);
+  });
+
+  it('should send token in POST request', async () => {
+    const token = '654321';
+    client = new Client({
+      port: port,
+      token: token
+    });
+
+    server = start([
+      seenDeepEqual(false),
+      parseBody(),
+      reqDeepEqual('body', JSON.stringify({token})),
+      end()
+    ]);
+
+    await client.post('/');
+    assert(seen);
+  });
+
+  it('should handle 401', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      status(401),
+      end()
+    ]);
+
+    let err;
+
+    try {
+      await client.get('/');
+    } catch (e) {
+      err = e;
+    }
+
+    assert.deepEqual(err.message, 'Unauthorized (bad API key).');
+    assert(seen);
+  });
+
+  it('should get JSON response', async () => {
+    client = new Client({port});
+
+    const input = {foo: 'bar'};
+
+    server = start([
+      seenDeepEqual(false),
+      write(input, 'json'),
+      unsafeEnd()
+    ]);
+
+    const response = await client.get('/');
+
+    assert.deepEqual(input, response);
+    assert(seen);
+  });
+
+  it('should not error when error object in response', async () => {
+    client = new Client({port});
+
+    const input = {error: 'foobar'};
+
+    server = start([
+      seenDeepEqual(false),
+      write(input, 'json'),
+      unsafeEnd()
+    ]);
+
+    const response = await client.get('/');
+
+    assert.deepEqual(input, response);
+    assert(seen);
+  });
+
+  it('should error when error object and error code', async () => {
+    client = new Client({port});
+
+    const error = {
+      message: 'error!',
+      type: 0,
+      code: 400
+    };
+
+    const input = {error};
+
+    server = start([
+      seenDeepEqual(false),
+      status(400),
+      write(input, 'json'),
+      unsafeEnd()
+    ]);
+
+    let err;
+
+    try {
+      await client.get('/');
+    } catch (e) {
+      err = e;
+    }
+
+    assert.deepEqual(err.message, error.message);
+    assert.deepEqual(err.type, error.type.toString());
+    assert.deepEqual(err.code, error.code);
+  });
+
+  it('should error on non 200 status code', async () => {
+    client = new Client({port});
+
+    server = start([
+      seenDeepEqual(false),
+      status(201),
+      end()
+    ]);
+
+    let err;
+    try {
+      await client.get('/');
+    } catch (e) {
+      err = e;
+    }
+
+    assert.deepEqual(err.message, 'Status code: 201.');
+    assert(seen);
+  });
+
+  describe('Path normalization', function() {
+    // base, input, expect
+    const mocks = [
+      ['', '/foo//', '/foo/'],
+      ['/', '/bar/', '/bar/'],
+      ['/', '/bar', '/bar'],
+      ['/foo/', '/bar/', '/foo/bar/']
+    ];
+
+    for (const [base, input, expect] of mocks) {
+      it(`${base + input} -> ${expect}`, async () => {
+        client = new Client({
+          port: port,
+          path: base
+        });
+
+        server = start([
+          seenDeepEqual(false),
+          reqDeepEqual('url', expect),
+          end()
+        ]);
+
+        await client.get(input);
+        assert(seen);
+      });
+    }
+  });
+});

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -1,5 +1,7 @@
 /**
  * http-test.js - HTTP tests for bcurl
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ * https://github.com/bcoin-org/bweb
  */
 
 'use strict';


### PR DESCRIPTION
- Fixes regression from https://github.com/bcoin-org/bcurl/pull/10, sometimes APIs will return an empty error object but the previous change had side effects that caused expected behavior to change for `bweb` errors
- Use `Path.posix` to join the http path, to deduplicate any `/`'s
- Adds test coverage
- Adds a CI config file