### PR TITLE
bcurl: use 127.0.0.1 by default.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -368,7 +368,7 @@ class ClientOptions {
   constructor(options) {
     this.ssl = false;
     this.strictSSL = true;
-    this.host = 'localhost';
+    this.host = '127.0.0.1';
     this.port = 80;
     this.path = '/';
     this.headers = null;

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -163,14 +163,13 @@ describe('Client HTTP', function() {
       seenDeepEqual(false),
       reqHeaderDeepEqual('user-agent', 'brq'),
       reqHeaderDeepEqual('foo', 'bar'),
-      reqHeaderDeepEqual('host', `localhost:${port}`),
+      reqHeaderDeepEqual('host', `127.0.0.1:${port}`),
       end()
     ]);
 
     await client.get('/');
     assert(seen);
   });
-
 
   it('should send json rpc', async () => {
     client = new Client({port});
@@ -238,7 +237,7 @@ describe('Client HTTP', function() {
       end()
     ]);
 
-    await client.get('/')
+    await client.get('/');
     assert(seen);
   });
 


### PR DESCRIPTION
Issue https://github.com/handshake-org/hsd/issues/722.

We could instead overwrite the `options` in `hs-client` and don't touch bcurl. But this seemed cleaner.